### PR TITLE
(#44) rm wrong entries

### DIFF
--- a/verbs/SBJR_error.corrected
+++ b/verbs/SBJR_error.corrected
@@ -1,4 +1,0 @@
-dessorri	dessorrir+V+IMP+SG
-entressorri	entressorrir+V+IMP+SG
-ri	rir+V+IMP+SG
-sorri	sorrir+V+IMP+SG

--- a/verbs/xau.delaf.dict
+++ b/verbs/xau.delaf.dict
@@ -7753,7 +7753,6 @@ dessorrida	dessorrir+V+PTPASS+F+SG
 dessorridas	dessorrir+V+PTPASS+F+PL
 dessorride	dessorrir+V+IMP+2+PL
 dessorrides	dessorrir+V+PRS+2+PL
-dessorri	dessorrir+V+IMP+2+SBJR
 dessorri	dessorrir+V+PRF+1+SG
 dessorri	dessorrir+V+PRS+3+SG
 dessorrido	dessorrir+V+PTPASS+M+SG

--- a/verbs/xba.delaf.dict
+++ b/verbs/xba.delaf.dict
@@ -6452,7 +6452,6 @@ entressorrido	entressorrir+V+PTPASS+M+SG
 entressorridos	entressorrir+V+PTPASS+M+PL
 entressorríeis	entressorrir+V+IMPF+2+PL
 entressorriem	entressorrir+V+PRS+3+PL
-entressorri	entressorrir+V+IMP+2+SBJR
 entressorri	entressorrir+V+PRF+1+SG
 entressorri	entressorrir+V+PRS+3+SG
 entressorrimos	entressorrir+V+PRF+1+PL

--- a/verbs/xbs.delaf.dict
+++ b/verbs/xbs.delaf.dict
@@ -14859,7 +14859,6 @@ riria	rir+V+COND+1+SG
 riria	rir+V+COND+3+SG
 ririas	rir+V+COND+2+SG
 riríeis	rir+V+COND+2+PL
-ri	rir+V+IMP+2+SBJR
 ri	rir+V+PRF+1+SG
 ri	rir+V+PRS+3+SG
 rirmos	rir+V+INF+1+PL

--- a/verbs/xbu.delaf.dict
+++ b/verbs/xbu.delaf.dict
@@ -6510,7 +6510,6 @@ sorrir	sorrir+V+INF+1+SG
 sorrir	sorrir+V+INF+3+SG
 sorrir	sorrir+V+SBJF+1+SG
 sorrir	sorrir+V+SBJF+3+SG
-sorri	sorrir+V+IMP+2+SBJR
 sorri	sorrir+V+PRF+1+SG
 sorri	sorrir+V+PRS+3+SG
 sorrísseis	sorrir+V+SBJP+2+PL


### PR DESCRIPTION
- rm duplicate entries

as entradas em `SBJR_error.corrected` já existiam, vindas do Freeling ou Garcia.

removi as entradas erradas tb, que ainda contavam com SBJR.